### PR TITLE
chore: add plugin support metadata

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "git+https://github.com/aklinker1/vitepress-knowledge.git"
   },
+  "homepage": "https://github.com/aklinker1/vitepress-knowledge",
+  "bugs": {
+    "url": "https://github.com/aklinker1/vitepress-knowledge/issues"
+  },
   "keywords": [
     "vitepress",
     "vitepress-plugin",


### PR DESCRIPTION
## Summary
- add missing `homepage` metadata to the `vitepress-knowledge` plugin package
- add `bugs.url` pointing to the repository issue tracker
- leave the unpublished backend package unchanged

## Verification
- package metadata assertion for `plugin/package.json`
- `npm pack --dry-run --ignore-scripts --json` in `plugin`
- `git diff --check`

This is a plugin package manifest-only change; runtime code, dependencies, exports, generated output, and package versioning are unchanged.